### PR TITLE
Fix message.author.bot

### DIFF
--- a/src/User.cpp
+++ b/src/User.cpp
@@ -9,6 +9,8 @@ namespace dpp {
 		discriminator = props["discriminator"];
 		if (!props["bot"].is_null())
 			bot = props["bot"];
+		else
+			bot = false;
 		if (!props["email"].is_null())
 			email = props["email"];
 	}


### PR DESCRIPTION
Like [Hideaki](https://github.com/HideakiAtsuyo) mentioned on #14, Message::author::bot was not behaving as expected. 
That's why discord's gateway doesn't always send that field in the MESSAGE_CREATE event, and we weren't handling that.